### PR TITLE
Add header Payload-URI

### DIFF
--- a/src/main/java/org/holodeckb2b/backend/rest/HTTPHeaders.java
+++ b/src/main/java/org/holodeckb2b/backend/rest/HTTPHeaders.java
@@ -125,7 +125,10 @@ public class HTTPHeaders {
 	 * ebMS Errors.   
 	 */
 	public static final String ERROR_MESSAGE = "X-HolodeckB2B-Errors";
-	
+	/**
+	 * The uri of the payload - Only used in <i>Submit</i> operation. Optional.
+	 */
+	public static final String PAYLOAD_URI = "X-HolodeckB2B-Payload-URI";
 	
 	private final HashMap<String, String> headers = new HashMap<>();
 	

--- a/src/main/java/org/holodeckb2b/backend/rest/SubmitOperation.java
+++ b/src/main/java/org/holodeckb2b/backend/rest/SubmitOperation.java
@@ -207,6 +207,10 @@ public class SubmitOperation extends AbstractMessageReceiver {
 			payload.setSchemaReference(schemaInfo);
 		}
 		
+		final String payloadURI = headers.getHeader(HTTPHeaders.PAYLOAD_URI);
+		if (!Utils.isNullOrEmpty(payloadURI))
+			payload.setPayloadURI(payloadURI);
+
 		return payload;
 	}
 


### PR DESCRIPTION
For the submit operation the functionality for settting
the payloadURI is added.
This header is optional and only used in submit operations if
a value is given.

https://github.com/holodeck-b2b/rest-backend/issues/10